### PR TITLE
Feature/Add a fake data generator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,16 +116,38 @@ Finally, the DevOps Testing Library also allows you to easily use Behave! BDD to
 the following code in your `features/environment.py` file
 
 ```python
-from connect.devops_testing.bdd.fixtures import use_connect_request_dispatcher, use_connect_request_builder
+from behave import use_fixture
+
 # import the built-in steps for e2e testing. 
 from connect.devops_testing.bdd import steps
+from connect.devops_testing.bdd.fixtures import (
+    use_connect_request_dispatcher,
+    use_connect_request_builder,
+    use_connect_request_store,
+)
 
 
 def before_all(context):
-    # attach the request dispatcher to the behave context if you want do e2e test.
-    use_connect_request_dispatcher(context)
+    # attach the request dispatcher to the behave context.
+    use_fixture(
+        fixture_func=use_connect_request_dispatcher,
+        context=context,
+    )
     # attach the request builder to the behave context.
-    use_connect_request_builder(context)
+    use_fixture(
+        fixture_func=use_connect_request_builder,
+        context=context,
+    )
+
+
+def before_feature(context, feature):
+    # reset the request store for each feature
+    use_fixture(
+        fixture_func=use_connect_request_store,
+        context=context,
+        reset=True
+    )
+
 ```
 
 It's time to define the feature file in `features/purchase.feature`:

--- a/connect/devops_testing/bdd/fixtures.py
+++ b/connect/devops_testing/bdd/fixtures.py
@@ -1,11 +1,13 @@
 from typing import Optional
 
+from behave import fixture
 from behave.runner import Context
 
 from connect.client import ConnectClient
 from connect.devops_testing.fixtures import make_request_builder, make_request_dispatcher
 
 
+@fixture
 def use_connect_request_dispatcher(
         context: Context,
         api_key: Optional[str] = None,
@@ -37,9 +39,24 @@ def use_connect_request_dispatcher(
     )
     context.timeout = timeout
     context.max_attempts = max_attempts
-    context.request = {}
+
+    use_connect_request_store(context)
 
 
+@fixture
+def use_connect_request_store(context: Context, reset: bool = False):
+    """
+    Provides a simple way initialize (or reset) the request store.
+
+    :param context: Context
+    :param reset: bool True to reset the request store.
+    :return: None
+    """
+    if not hasattr(context, 'request') or reset:
+        context.request = {}
+
+
+@fixture
 def use_connect_request_builder(context: Context, parameters: Optional[dict] = None):
     """
     Provides a connect request builder into the behave Context object.

--- a/connect/devops_testing/bdd/steps.py
+++ b/connect/devops_testing/bdd/steps.py
@@ -21,11 +21,14 @@ def _get_request_handler(asset: Callable, tier_config: Callable, request_type: s
 
 
 def _request_is_process(context: Context):
-    context.request = context.connect.provision_request(
+    if isinstance(context.request, dict) and context.request.get('id') is not None:
+        context.builder.with_id(context.request.get('id'))
+
+    context.request.update(context.connect.provision_request(
         request=context.builder.build(),
         timeout=context.timeout,
         max_attempt=context.max_attempts,
-    )
+    ))
 
 
 def _with_checkbox_parameter(context: Context, parameter: str, values: str, checked: bool):
@@ -70,11 +73,14 @@ def tier_configuration_request_is_processed(context: Context):
 @step('tier config request')
 def tier_config_request(context: Context):
     context.builder = context.builder.from_default_tier_config()
+    context.builder = context.builder.with_tier_configuration_account('random')
 
 
 @step('asset request')
 def asset_request(context: Context):
     context.builder = context.builder.from_default_asset()
+    context.builder = context.builder.with_asset_tier_customer('random')
+    context.builder = context.builder.with_asset_tier_tier1('random')
 
 
 @step('request with id "{request_id}"')
@@ -90,6 +96,21 @@ def with_status(context: Context, request_status: str):
 @step('request with configuration account "{account_id}"')
 def with_tier_config_account(context: Context, account_id: str):
     context.builder.with_tier_configuration_account(account_id)
+
+
+@step('request with asset customer "{customer_id}"')
+def with_asset_tier_customer(context: Context, customer_id: str):
+    context.builder.with_asset_tier_customer(customer_id)
+
+
+@step('request with asset tier1 "{tier1_id}"')
+def with_asset_tier_tier1(context: Context, tier1_id: str):
+    context.builder.with_asset_tier_tier1(tier1_id)
+
+
+@step('request with asset tier2 "{tier2_id}"')
+def with_asset_tier_tier2(context: Context, tier2_id: str):
+    context.builder.with_asset_tier_tier2(tier2_id)
 
 
 @step('request with product "{product_id}"')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 python = "^3.8"
 behave = "^1.2.*"
 connect-openapi-client = "^23.*"
+Faker = "^9.8.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.2"

--- a/tests/bdd/test_steps.py
+++ b/tests/bdd/test_steps.py
@@ -8,6 +8,7 @@ from connect.devops_testing.bdd.steps import (
     subscription_request_is_processed, tier_configuration_request_is_processed, parameter_value_contains,
     parameter_value_error_contains, parameter_value_match, parameter_value_error_match, with_parameter_checked,
     with_parameter_not_checked, with_parameter_without_value, with_parameter_without_value_error,
+    with_asset_tier_customer, with_asset_tier_tier1, with_asset_tier_tier2,
 )
 
 PARAM_ID_A = 'PARAM_ID_A'
@@ -94,6 +95,9 @@ def test_step_should_create_an_asset_request(behave_context):
     with_status(behave_context, 'pending')
     with_product_id(behave_context, 'PRD-000-000-000')
     with_marketplace_id(behave_context, 'MP-00000')
+    with_asset_tier_customer(behave_context, 'TA-0000-0000-0000')
+    with_asset_tier_tier1(behave_context, 'TA-0000-0000-0001')
+    with_asset_tier_tier2(behave_context, 'TA-0000-0000-0002')
     with_parameter_with_value(behave_context, PARAM_ID_A, PARAM_ID_A_VALUE)
     with_parameter_with_value_error(behave_context, PARAM_ID_A, PARAM_ID_A_VALUE_ERROR)
     with_parameter_without_value(behave_context, PARAM_ID_NO_VALUE)
@@ -106,6 +110,9 @@ def test_step_should_create_an_asset_request(behave_context):
     assert request['type'] == 'purchase'
     assert request['asset']['product']['id'] == 'PRD-000-000-000'
     assert request['asset']['marketplace']['id'] == 'MP-00000'
+    assert request['asset']['tiers']['customer']['id'] == 'TA-0000-0000-0000'
+    assert request['asset']['tiers']['tier1']['id'] == 'TA-0000-0000-0001'
+    assert request['asset']['tiers']['tier2']['id'] == 'TA-0000-0000-0002'
     assert request['asset']['params'][0]['id'] == PARAM_ID_A
     assert request['asset']['params'][0]['value'] == PARAM_ID_A_VALUE
     assert request['asset']['params'][0]['value_error'] == PARAM_ID_A_VALUE_ERROR
@@ -144,11 +151,12 @@ def test_step_should_successfully_process_the_request(sync_client_factory, respo
         tier_configuration_request_is_processed
     ]
 
+    behave_context.request = {'id': 'PR-000-000-000-000'}
+
     for process_step in process_steps:
         use_connect_request_builder(context=behave_context)
 
         asset_request(behave_context)
-        with_id(behave_context, 'PR-000-000-000-000')
         with_status(behave_context, 'pending')
 
         mocked_client = sync_client_factory([

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -149,6 +149,25 @@ def test_request_builder_should_build_successfully_a_valid_tier_config_request()
     assert request['params'][2]['value_error'] == 'Some value error on configuration'
 
 
+def test_request_builder_should_build_successfully_a_valid_tier_config_request_with_random_account_data():
+    request = (Builder()
+               .with_type('setup')
+               .with_status('approved')
+               .with_id('TCR-000-000-000-100')
+               .with_tier_configuration_id('TC-000-000-000')
+               .with_tier_configuration_account('random'))
+
+    assert request.is_tier_config_request()
+
+    request = request.build()
+
+    assert request['id'] == 'TCR-000-000-000-100'
+    assert request['type'] == 'setup'
+    assert request['status'] == 'approved'
+
+    assert 'contact_info' in request['configuration']['account']
+
+
 def test_request_builder_should_build_successfully_a_valid_request_from_file_template():
     template = os.path.dirname(__file__) + TPL_REQUEST_ASSET
 


### PR DESCRIPTION
* Now if the request store contains a valid request the id, it will be used across the same feature, allowing to use of one request across several scenarios.
* Faker data generator has been added.
* Now you can generate random tier data by using with_asset_tier_customer, with_asset_tier_tier1, with_asset_tier_tier2, and with_tier_configuration_account by passing the string 'random' as id.