### PR TITLE
Feature/CEDT-6 BDD steps improvements.

### DIFF
--- a/connect/devops_testing/bdd/steps.py
+++ b/connect/devops_testing/bdd/steps.py
@@ -57,9 +57,9 @@ def _with_parameter_without_value(context: Context, parameter: str):
 
 def _with_item(context: Context, item_id: str, item_mpn: str, quantity: str):
     context.builder.with_asset_item(
-        item_id=item_id,
-        item_mpn=item_mpn,
-        quantity=quantity,
+        item_id=context.shared(item_id),
+        item_mpn=context.shared(item_mpn),
+        quantity=context.shared(quantity),
     )
 
 
@@ -121,6 +121,16 @@ def with_note(context: Context, note: str):
 @step('request with configuration account "{account_id}"')
 def with_tier_config_account(context: Context, account_id: str):
     context.builder.with_tier_configuration_account(context.shared(account_id))
+
+
+@step('request with tier config id "{tier_config_id}"')
+def with_tier_config_id(context: Context, tier_config_id: str):
+    context.builder.with_tier_configuration_id(context.shared(tier_config_id))
+
+
+@step('request with asset id "{asset_id}"')
+def with_asset_id(context: Context, asset_id: str):
+    context.builder.with_asset_id(context.shared(asset_id))
 
 
 @step('request with asset external id "{external_id}"')

--- a/tests/bdd/test_steps.py
+++ b/tests/bdd/test_steps.py
@@ -10,7 +10,7 @@ from connect.devops_testing.bdd.steps import (
     with_parameter_not_checked, with_parameter_without_value, with_parameter_without_value_error,
     with_asset_tier_customer, with_asset_tier_tier1, with_asset_tier_tier2, with_connection_id, with_item_quantity,
     with_items, request_note_is, request_reason_is, with_note, with_reason, with_asset_tier_from_country,
-    with_asset_external_id, with_asset_external_uid, with_type,
+    with_asset_external_id, with_asset_external_uid, with_tier_config_id, with_asset_id, with_type,
 )
 
 PARAM_ID_A = 'PARAM_ID_A'
@@ -54,6 +54,7 @@ def test_step_should_create_a_tier_configuration_request(behave_context):
     with_note(behave_context, NOTE)
     with_reason(behave_context, REASON)
     with_status(behave_context, 'pending')
+    with_tier_config_id(behave_context, 'TC-000-000-000')
     with_product_id(behave_context, 'PRD-000-000-000')
     with_marketplace_id(behave_context, 'MP-00000')
     with_connection_id(behave_context, 'CT-0000-0000-0000', 'test')
@@ -122,6 +123,7 @@ def test_step_should_create_an_asset_request(behave_context):
     with_product_id(behave_context, 'PRD-000-000-000')
     with_note(behave_context, NOTE)
     with_reason(behave_context, REASON)
+    with_asset_id(behave_context, 'AS-000-000-000')
     with_marketplace_id(behave_context, 'MP-00000')
     with_connection_id(behave_context, 'CONNECTION_ID', 'test')
     with_asset_external_id(behave_context, '123456789')


### PR DESCRIPTION
Added with_asset_id and with_tier_config_id steps.

```bash
# Asset request
Given asset request
And request with asset id "AS-0000-0000-0000"
# Tier Config request 
Given tier config request
And request with tier config id "TC-0000-0000-0000"
```

Also, now the with_item_quantity uses the shared value repository to replace the given values if required.

```python
use_connect_request_builder(
        context=behave_context,
        shared={
              'ITEM_ID_01': 'PRD-507-873-486-0018',
              'ITEM_MPN_01': 'SOME_MPN_1',
              'ITEM_QTY_01': '25',
              'ITEM_ID_02': 'PRD-507-873-486-0022',
              'ITEM_MPN_02': 'SOME_MPN_2',
              'ITEM_QTY_02': '33',
        },
    )
```


```
Given asset request
And request with item "ITEM_ID_01" with mpn "ITEM_MPN_01" xITEM_QTY_01
And request with item "ITEM_ID_02" with mpn "ITEM_MPN_02" xITEM_QTY_02
```
