### PR TITLE
Updated faker version for compatibility with other connect libraries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 python = "^3.8"
 behave = "^1.2"
 connect-openapi-client = "*"
-Faker = "^9.8.2"
+Faker = "^15.3.4"
 Pygments = "^2.13.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
The RNDI library https://github.com/IM-Cloud-Spain-Connectors/python-connect-business-objects
depends on a newer version of the faker,
so it cannot be used with the current project as running `poetry install` gives dependency conflict.
