### PR TITLE
Updated faker version for compatibility with other connect libraries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 python = ">=3.7,<4"
 behave = "^1.2"
 connect-openapi-client = "^25.0"
-Faker = "^9.8.2"
+Faker = "^15.3.4"
 Pygments = "^2.13.0"
 
 [tool.poetry.dev-dependencies]
@@ -99,4 +99,3 @@ max_line_length = 120
 import-order-style = 'smarkets'
 max_cognitive_complexity = 15
 ignore = ['FI1', 'I100', 'W503', 'FI58']
-


### PR DESCRIPTION
The RNDI library https://github.com/IM-Cloud-Spain-Connectors/python-connect-business-objects
depends on a newer version of the faker,
so it cannot be used with the current project as running poetry install gives dependency conflict.